### PR TITLE
Added option to use port number as command line arg

### DIFF
--- a/TerminalExtension/spawner.js
+++ b/TerminalExtension/spawner.js
@@ -1,7 +1,7 @@
 (function() {
   var portRange = [26490, 26999];
   var portIndex = portRange[0];
-  var serverPort= 8080;
+  var serverPort= parseInt(process.argv[2],10) || 8080;
   var instances = {};
 
   var fs = require('fs');


### PR DESCRIPTION
You can add a different port number other than 8080 as a command line arg. If you choose not to use a command line arg, it will default to port 8080.
